### PR TITLE
Use scikit-build to build the extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+# scikit-build test
+if(SKBUILD)
+    message(STATUS "The project is built using scikit-build")
+endif()
+
+message(STATUS "The generator is: ${CMAKE_GENERATOR}")
+message(STATUS "The build type is: ${CMAKE_BUILD_TYPE}")
+message(STATUS "The toolchain is: ${CMAKE_TOOLCHAIN_FILE}")
+
+
+# set the project name
+project(videoplayer)
+
+
+if (POLICY CMP0072)
+    cmake_policy(SET CMP0072 OLD)
+endif(POLICY CMP0072)
+
+# manage dependencies
+## set vars
+set(USE_WIN_DEP OFF CACHE BOOL "Use dependencies from an external package")
+
+## find python deps
+find_package(Python REQUIRED)
+find_package(PythonExtensions REQUIRED)
+find_package(Cython REQUIRED)
+
+## get deps
+if (WIN32 AND USE_WIN_DEP)
+    message(STATUS "Use downloaded dependencies")
+
+    set(DEPENDENCY_FOLDER "${PROJECT_SOURCE_DIR}/win_dep")
+    find_path(GLIB2_INCLUDE_DIRS NAMES glib.h PATHS "${DEPENDENCY_FOLDER}/include/glib-2.0")
+    find_library(GLIB2_LIBRARIES NAMES glib-2.0 PATHS "${DEPENDENCY_FOLDER}/lib")
+    find_library(OGG_LIBRARIES NAMES ogg libogg PATHS "${DEPENDENCY_FOLDER}/lib")
+    find_library(THEORADEC_LIBRARIES NAMES theoradec libtheoradec theora-dec PATHS "${DEPENDENCY_FOLDER}/lib")
+    find_library(LIBSWSCALE_LIBRARIES NAMES swscale libswscale PATHS "${DEPENDENCY_FOLDER}/lib")
+    find_package(OpenGL)
+
+else()
+    message(STATUS "Use pkgconfig")
+
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(GLIB2 REQUIRED glib-2.0>=2.28 IMPORTED_TARGET)
+    pkg_search_module(OGG ogg>=1.3.0 IMPORTED_TARGET)  # OGG::OGG
+    pkg_search_module(THEORADEC theoradec>=1.1.0 IMPORTED_TARGET)  # THEORA::DEC
+    #pkg_search_module(LIBSWSCALE libswscale>=1.1.3)  # FFMPEG::swscale
+    find_path(LIBSWSCALE_INCLUDE_DIRS
+        NAMES libswscale/swscale.h
+        PATH_SUFFIXES include include/ffmpeg
+    )
+    find_library(LIBSWSCALE_LIBRARIES
+        NAMES swscale
+        PATH_SUFFIXES bin lib
+    )
+    find_package(OpenGL)
+    #pkg_search_module(OPENGL REQUIRED gl IMPORTED_TARGET)
+endif()
+
+
+# build the project
+add_subdirectory(videoplayer)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You'll need those packages:
 * `libtheora`
 * `libswscale` (part of `ffmpeg`).
 
+You'll also need some python package:
+
+    pip install -r requirements.txt
+
 
 ### Native modules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires=["setuptools", "wheel", "cython", "pkgconfig"]
+requires=["setuptools", "wheel", "scikit-build", "cmake", "ninja", "cython"]
 #build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+scikit-build>=0.10.0
+cython>=0.29.16

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ ext = Extension(
 # setup
 setup(
     name='videoplayer',
-    version='1.0',
+    version='1.1.dev0',
     description='VideoPlayer is a C-extension in Python',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,12 @@
 #!/usr/bin/env python
 
 
-# from distutils.core import setup
-# from distutils.extension import Extension
-# from distutils.sysconfig import get_python_lib
 from distutils.command.clean import clean as Clean
-from setuptools import setup
-from setuptools import Extension
+try:
+    from skbuild import setup
+except ImportError:
+    from setuptools import setup
 import os
-import sys
-
-from Cython.Build import cythonize
-# from Cython.Distutils import build_ext
-import pkgconfig
 
 
 class CleanCommand(Clean):
@@ -39,56 +33,6 @@ class CleanCommand(Clean):
                         os.unlink(os.path.join(dirpath, filename))
 
 
-def pc_info(pkg):
-    """
-    Obtain build options for a library from pkg-config and return a dict
-    that can be expanded into the argument list for Extension.
-    """
-
-    sys.stdout.write('checking for library %s... ' % pkg)
-
-    # pkg not found
-    if not pkgconfig.exists(pkg):
-        sys.stdout.write('not found')
-        sys.stderr.write('Could not find required library "%s".\n' % pkg)
-        sys.exit(1)
-
-    # get infos about the pkg
-    pkg_info = pkgconfig.parse(pkg)
-    info = {
-        'define_macros': pkg_info['define_macros'],
-        'include_dirs': pkg_info['include_dirs'],
-        'libraries': pkg_info['libraries'],
-        'library_dirs': pkg_info['library_dirs'],
-    }
-    sys.stdout.write('ok\n')
-    #sys.stdout.write('- cflags: %s\n' % cflags)
-    #sys.stdout.write('- libs: %s\n' % libs)
-
-    return info
-
-
-def combine_info(*args):
-    """ Combine multiple result dicts from L{pc_info} into one. """
-
-    # init
-    info = {
-        'define_macros': [],
-        'include_dirs': [],
-        'libraries': [],
-        'library_dirs': [],
-    }
-
-    # fill
-    for a in args:
-        info['define_macros'].extend(a.get('define_macros', []))
-        info['include_dirs'].extend(a.get('include_dirs', []))
-        info['libraries'].extend(a.get('libraries', []))
-        info['library_dirs'].extend(a.get('library_dirs', []))
-
-    return info
-
-
 # Readme
 readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
 try:
@@ -96,34 +40,6 @@ try:
     long_description = pypandoc.convert(readme_filepath, 'rst')
 except ImportError:
     long_description = open(readme_filepath).read()
-
-
-# find dependencies
-gl_info = pc_info('gl')
-glib_info = pc_info('glib-2.0')
-ogg_info = pc_info('ogg')
-swscale_info = pc_info('libswscale')
-theoradec_info = pc_info('theoradec')
-
-
-# sources
-ext_sources = [
-    'videoplayer/_VideoPlayer.pyx',
-    'videoplayer/VideoPlayer.c'
-]
-
-# extension
-ext = Extension(
-    name='videoplayer._VideoPlayer',
-    sources=ext_sources,
-    **combine_info(
-        gl_info,
-        glib_info,
-        ogg_info,
-        swscale_info,
-        theoradec_info
-    )
-)
 
 # setup
 setup(
@@ -150,12 +66,12 @@ setup(
         'Topic :: Software Development :: Libraries',
     ],
     keywords='ogg',
-    ext_modules=cythonize(ext, compiler_directives={'language_level': sys.version_info[0]}),
-    setup_requires=['cython', 'pytest-runner'],
-    install_requires=[
-        'Cython >= 0.27',
-        'pkgconfig >= 1.5',
-    ],
+    #ext_modules=cythonize(ext, compiler_directives={'language_level': sys.version_info[0]}),
+    #setup_requires=['cython', 'pytest-runner', 'cmake'],
+    setup_requires=['pytest-runner', 'cmake'],
+    #install_requires=[
+    #    'Cython >= 0.27',
+    #],
     test_suite="tests",
     tests_require=['pytest'],
     extras_require={

--- a/videoplayer/CMakeLists.txt
+++ b/videoplayer/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Steps:
+# - compile the external lib
+# - cythonize the pyx file (to get a C file)
+# - compile the extension
+# - install the module
+
+# cythonize the pyx file
+add_cython_target(_VideoPlayer _VideoPlayer.pyx)
+
+# compile the extension with the lib
+add_library(_VideoPlayer MODULE ${_VideoPlayer} VideoPlayer.c)
+target_include_directories(_VideoPlayer
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${GLIB2_INCLUDE_DIRS}
+)
+target_link_libraries(_VideoPlayer
+    ${GLIB2_LIBRARIES}
+    ${OGG_LIBRARIES}
+    ${THEORADEC_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${LIBSWSCALE_LIBRARIES}
+)
+python_extension_module(_VideoPlayer)
+
+# install the module
+# skbuild: add_python_extension
+install(TARGETS _VideoPlayer
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/videoplayer
+    PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Copy dlls on windows
+if (WIN32)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/avutil-56.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/glib-2.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libcharset.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libiconv.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libintl.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/ogg.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/pcre.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/swscale-5.dll)
+    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/theoradec.dll)
+    install(FILES ${DEPENDENCIES_DLL}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/videoplayer)
+endif()

--- a/videoplayer/_VideoPlayer.pyx
+++ b/videoplayer/_VideoPlayer.pyx
@@ -23,7 +23,7 @@
 
 # First a thin wrapper around VideoPlayer from graphics.VideoPlayer.c...
 
-__version__ = "1.0"
+__version__ = "1.1.dev0"
 
 cdef extern from "VideoPlayer.h":
     ctypedef struct CVideoPlayer "VideoPlayer":


### PR DESCRIPTION
Using a dependency pack for Windows is now optional and is not needed anymore in the package to install it. Then, installing with pip is easier.