### PR TITLE
fix(tests): import urllib.request instead of invoking it

### DIFF
--- a/tests/test_videoplayer.py
+++ b/tests/test_videoplayer.py
@@ -4,14 +4,15 @@
 import os
 import sys
 import unittest
-import urllib
 
 from videoplayer._VideoPlayer import VideoPlayer
 from videoplayer._VideoPlayer import VideoPlayerError
 
 
 if sys.version_info.major == 3:
-    urllib = urllib.request
+    import urllib.request as urllib
+else:
+    import urllib
 
 
 class VideoPlayerTest(unittest.TestCase):


### PR DESCRIPTION
It is more supported to import `urllib.request` directly in python 3 than importing `urllib` then invoking `urllib.request`.