### PR TITLE
build(cmake): fix support for Windows with dep pack and macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,18 +43,23 @@ else()
     message(STATUS "Use pkgconfig")
 
     find_package(PkgConfig REQUIRED)
-    pkg_search_module(GLIB2 REQUIRED glib-2.0>=2.28 IMPORTED_TARGET)
-    pkg_search_module(OGG ogg>=1.3.0 IMPORTED_TARGET)  # OGG::OGG
-    pkg_search_module(THEORADEC theoradec>=1.1.0 IMPORTED_TARGET)  # THEORA::DEC
-    #pkg_search_module(LIBSWSCALE libswscale>=1.1.3)  # FFMPEG::swscale
-    find_path(LIBSWSCALE_INCLUDE_DIRS
-        NAMES libswscale/swscale.h
-        PATH_SUFFIXES include include/ffmpeg
-    )
-    find_library(LIBSWSCALE_LIBRARIES
-        NAMES swscale
-        PATH_SUFFIXES bin lib
-    )
+    pkg_search_module(GLIB2 REQUIRED glib-2.0>=2.12 IMPORTED_TARGET)
+    pkg_search_module(OGG ogg>=1.1.0 IMPORTED_TARGET)  # OGG::OGG
+    pkg_search_module(THEORADEC theoradec IMPORTED_TARGET)  # THEORA::DEC
+
+    if(APPLE)
+        find_path(LIBSWSCALE_INCLUDE_DIRS
+            NAMES libswscale/swscale.h
+            PATH_SUFFIXES include include/ffmpeg
+        )
+        find_library(LIBSWSCALE_LIBRARIES
+            NAMES swscale
+            PATH_SUFFIXES bin lib
+        )
+    else()
+        pkg_search_module(LIBSWSCALE libswscale>=1.1.3)  # FFMPEG::swscale
+    endif()
+
     find_package(OpenGL)
     #pkg_search_module(OPENGL REQUIRED gl IMPORTED_TARGET)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,29 @@ if (WIN32 AND USE_WIN_DEP)
     message(STATUS "Use downloaded dependencies")
 
     set(DEPENDENCY_FOLDER "${PROJECT_SOURCE_DIR}/win_dep")
-    find_path(GLIB2_INCLUDE_DIRS NAMES glib.h PATHS "${DEPENDENCY_FOLDER}/include/glib-2.0")
-    find_library(GLIB2_LIBRARIES NAMES glib-2.0 PATHS "${DEPENDENCY_FOLDER}/lib")
-    find_library(OGG_LIBRARIES NAMES ogg libogg PATHS "${DEPENDENCY_FOLDER}/lib")
-    find_library(THEORADEC_LIBRARIES NAMES theoradec libtheoradec theora-dec PATHS "${DEPENDENCY_FOLDER}/lib")
+
+    # glib
+    find_path(GLIB2_INCLUDE_DIRS_0 NAMES glib.h PATHS "${DEPENDENCY_FOLDER}/include/glib-2.0")
+    find_path(GLIB2_INCLUDE_DIRS_1 NAMES glibconfig.h PATHS "${DEPENDENCY_FOLDER}/lib/glib-2.0/include")
+    list(APPEND GLIB2_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS_0})
+    list(APPEND GLIB2_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS_1})
+    find_library(GLIB2_LINK_LIBRARIES NAMES glib-2.0 PATHS "${DEPENDENCY_FOLDER}/lib")
+    # ogg
+    find_path(OGG_INCLUDE_DIRS NAMES ogg/ogg.h PATHS "${DEPENDENCY_FOLDER}/include/")
+    find_library(OGG_LINK_LIBRARIES NAMES ogg libogg PATHS "${DEPENDENCY_FOLDER}/lib")
+    # theora
+    find_path(THEORADEC_INCLUDE_DIRS NAMES theora/theoradec.h PATHS "${DEPENDENCY_FOLDER}/include")
+    find_library(THEORADEC_LINK_LIBRARIES NAMES theoradec libtheoradec theora-dec PATHS "${DEPENDENCY_FOLDER}/lib")
+    # libswscale
+    find_path(LIBSWSCALE_INCLUDE_DIRS NAMES libswscale/swscale.h PATHS "${DEPENDENCY_FOLDER}/include")
     find_library(LIBSWSCALE_LIBRARIES NAMES swscale libswscale PATHS "${DEPENDENCY_FOLDER}/lib")
+    # opengl
     find_package(OpenGL)
+    # msinttypes
+    find_path(MSINTTYPES_INCLUDE_DIRS_0 NAMES stdint.h PATHS "${DEPENDENCY_FOLDER}/include/msinttypes")
+    find_path(MSINTTYPES_INCLUDE_DIRS_1 NAMES inttypes.h PATHS "${DEPENDENCY_FOLDER}/include/msinttypes")
+    list(APPEND MSINTTYPES_INCLUDE_DIRS ${MSINTTYPES_INCLUDE_DIRS_0})
+    list(APPEND MSINTTYPES_INCLUDE_DIRS ${MSINTTYPES_INCLUDE_DIRS_1})
 
 else()
     message(STATUS "Use pkgconfig")

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ try:
 except ImportError:
     long_description = open(readme_filepath).read()
 
+# Windows
+build_cmake_args = list()
+if os.getenv("WIN_BUILD"):
+    build_cmake_args.append('-DUSE_WIN_DEP=ON')
+
 # setup
 setup(
     name='videoplayer',
@@ -80,4 +85,6 @@ setup(
     cmdclass={
         'clean': CleanCommand,
     },
+    # skbuild options
+    cmake_args=build_cmake_args,
 )

--- a/videoplayer/CMakeLists.txt
+++ b/videoplayer/CMakeLists.txt
@@ -12,11 +12,14 @@ add_library(_VideoPlayer MODULE ${_VideoPlayer} VideoPlayer.c)
 target_include_directories(_VideoPlayer
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${GLIB2_INCLUDE_DIRS}
+    PRIVATE ${OGG_INCLUDE_DIRS}         # for osx 10.9
+    PRIVATE ${THEORADEC_INCLUDE_DIRS}   # for osx 10.9
+    PRIVATE ${LIBSWSCALE_INCLUDE_DIRS}  # for osx
 )
 target_link_libraries(_VideoPlayer
-    ${GLIB2_LIBRARIES}
-    ${OGG_LIBRARIES}
-    ${THEORADEC_LIBRARIES}
+    ${GLIB2_LINK_LIBRARIES}
+    ${OGG_LINK_LIBRARIES}
+    ${THEORADEC_LINK_LIBRARIES}
     ${OPENGL_LIBRARIES}
     ${LIBSWSCALE_LIBRARIES}
 )

--- a/videoplayer/CMakeLists.txt
+++ b/videoplayer/CMakeLists.txt
@@ -11,6 +11,7 @@ add_cython_target(_VideoPlayer _VideoPlayer.pyx)
 add_library(_VideoPlayer MODULE ${_VideoPlayer} VideoPlayer.c)
 target_include_directories(_VideoPlayer
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${MSINTTYPES_INCLUDE_DIRS}  # for windows
     PRIVATE ${GLIB2_INCLUDE_DIRS}
     PRIVATE ${OGG_INCLUDE_DIRS}         # for osx 10.9
     PRIVATE ${THEORADEC_INCLUDE_DIRS}   # for osx 10.9
@@ -34,15 +35,23 @@ install(TARGETS _VideoPlayer
 
 # Copy dlls on windows
 if (WIN32)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/avutil-56.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/glib-2.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libcharset.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libiconv.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/libintl.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/ogg.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/pcre.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/swscale-5.dll)
-    list(APPEND DEPENDENCIES_DLL ${CMAKE_CURRENT_BINARY_DIR}/theoradec.dll)
-    install(FILES ${DEPENDENCIES_DLL}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/videoplayer)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/avutil-56.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/glib-2.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/libglib-2.0-0.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/libcharset.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/libiconv.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/libintl.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/ogg.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/libogg-0.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/pcre.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/swscale-5.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/theoradec-1.dll)
+    list(APPEND DEPENDENCIES_DLL ${DEPENDENCY_FOLDER}/bin/theoradec.dll)
+    foreach(DEP IN LISTS ${DEPENDENCIES_DLL})
+        if (EXISTS ${DEP})
+            install(FILES ${DEP} DESTINATION ${CMAKE_INSTALL_PREFIX}/videoplayer)
+        else()
+            message(STATUS "${DEP} not found")
+        endif()
+    endforeach()
 endif()


### PR DESCRIPTION
- Use `X_LINK_LIBRARIES` instead of `X_LIBRARIES`.
- Include some directories to the target.
- Fix `libswscale` module search.
- Get modules from the dep pack.
- Install DLL from the dep pack.
- Add `msinttypes` to the target directory.
- Add support to the dep pack in setup.py with `WIN_BUILD` env var.